### PR TITLE
README Refactor / Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,87 @@
-KanjiVG Website
-===============
+# KanjiVG
+*Code For The* ***[kanjivg.tagaini.net][Website]*** *Website.*
 
-This repository holds the KanjiVG website in form of hosted Github pages. Please see the [KanjiVG website](http://kanjivg.tagaini.net/) for more content.
+---
+
+## Content
+*Relevant Files / Non-Library Files.*
+
+<br>
+
+- **[`_layouts/default.html`][Layouts]**
+
+    *Layout For Every Page .*
+
+- **[`_config.yml`][Config]**
+
+    *Layout For Every Page .*
+
+- **[`js/kanjiviewer.js`][Viewer]**
+
+    *Kanji Visualization Logic .*
+
+- **[`kanjivg`][Kanji]**
+
+    ***[KanjiVG]*** *Github Submodule .*
+
+---
+
+## Pages
+
+**[404][Page 404]**
+
+*File Not Found .*
+
+**[Index][Page Index]**
+
+*Project Overview .*
+
+**[Incorrect Kanji][Page Incorrect Kanji]**
+
+*List Of Erroneous Kanji .*
+
+**[Conventions][Page Conventions]**
+
+*Project Conventions For Kanji SVGs .*
+
+**[Format][Page Format]**
+
+*Details The Kanji SVG Format .*
+
+
+**[Internationalization][Page Internationalization]**
+
+*Project Scope / Limitations .*
+
+**[Listing][Page Listing]**
+
+*All Kanji .*
+
+**[Projects][Page Projects]**
+
+*Projects using* ***KanjiVG*** *.*
+
+**[Viewer][Page Viewer]**
+
+*Kanji SVG Visualizer .*
+
+<!----------------------------------------------------------------------------->
+
+[Page 404]: 404.html
+[Page Conventions]: Conventions.html
+[Page Format]: Format.html
+[Page Incorrect Kanji]: incorrect-kanjis.html
+[Page Index]: index.html
+[Page Internationalization]: internationalization.html
+[Page Listing]: listing.html
+[Page Projects]: projects.html
+[Page Viewer]: viewer.html
+
+[Layouts]: _layouts/default.html
+[Config]: _config.yml
+[Viewer]: js/kanjiviewer.js
+[Kanji]: kanjivg
+
+[KanjiVG]: https://github.com/KanjiVG/kanjivg
+
+[Website]: https://kanjivg.tagaini.net/


### PR DESCRIPTION
- Formatting
- Linking / Description of relevant files
- Linking / Description of pages

I would like to suggest to:
- Update the repo description to ```KanjiVG Website```
- Add tags like
  - `github-pages`
  - `website`
  - `kanji`
  - `svg`
- Disable unused features like
   - `Actions`
   - `Wiki`
   - `Projects`
   - `Packages`
   - `Releases`
- Specify a license, **AGPL** possibly?
- In the future move **Source** files of the page
  into a dedicated folder, such as `docs`
  (Considering Github Pages only works in `/` & `/docs/`)
- In the future use a script to download the content of
  the **KanjiVG** project instead of cloning the whole
  folder as to not host literally all files of that repo.
  Such as [`http://kanjivg.tagaini.net/kanjivg/find-ie.pl`](http://kanjivg.tagaini.net/kanjivg/find-ie.pl)
  Also considering git submodules don't synchronize