### PR TITLE
Add jepang.org to projects

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -122,6 +122,10 @@ description: A list of projects which use the KanjiVG vector graphics
       kanji with interactive stroke order diagrams. Search, learn, and
       practice the correct way to write each character.
     </li>
+    <li><!-- Added 2026-02-02 -->
+      <a href="https://jepang.org/kanji">Jepang.org</a>, a comprehensive Japanese learning portal
+      for Indonesian speakers that uses KanjiVG for its Kanji reference section.
+    </li>
   </ul>
 </section>
 


### PR DESCRIPTION
Hi! I would like to add **Jepang.org** to the list of websites using KanjiVG.

We are a Japanese learning portal for Indonesian speakers and rely on KanjiVG data for our stroke order diagrams.

**Details:**
- **Usage Example:** https://jepang.org/kanji/
- **Attribution:** We have credited KanjiVG on our "About Us" page (bottom section): https://jepang.org/tentang-kami/

Thank you for maintaining this project!